### PR TITLE
Explicitly specify dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setup(name='webtest-selenium',
       zip_safe=False,
       install_requires=[
           # -*- Extra requirements: -*-
-          'webtest',
+          'WebOb',
+          'WebTest',
+          'six',
       ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
webtest-selenium depends on WebOb and six, but wasn't including them "install_requires" (it was relying on the fact that WebTest also depends on WebOb and six).  I feel it's cleaner to specify the dependencies regardless, since a change in WebTest's dependencies would potentially break webtest-selenium.
